### PR TITLE
Take-aways from running through

### DIFF
--- a/Main.elm
+++ b/Main.elm
@@ -54,6 +54,10 @@ initials firstName lastName =
 
 pigLatin : String -> String
 pigLatin word =
+    -- To go from English to pig latin, take the first letter of the word
+    -- and put it at the end of the word, followed by an "ay" sound.
+    -- Pig latin, in pig latin, is "Ig-pay atin-lay"
+    -- For this exercise, just worry about producing a single word in pig latin.
     "TODO: implement me"
 
 

--- a/Main.elm
+++ b/Main.elm
@@ -237,6 +237,22 @@ main =
                       }
                     )
               )
+            , ( ( { description = "Opening act"
+                  , location = "Stage"
+                  }
+                , { description = "Main performers"
+                  , location = "Backstage"
+                  }
+                )
+              , toString
+                    ( { description = "Opening act"
+                      , location = "Backstage"
+                      }
+                    , { description = "Main performers"
+                      , location = "Stage"
+                      }
+                    )
+              )
             ]
         , Html.h2 [] [ Html.text "Tuples" ]
         , viewFunctionExample1 "signAndMagnitude"

--- a/Main.elm
+++ b/Main.elm
@@ -301,17 +301,6 @@ viewUntypedExample name actual expected =
         ]
 
 
-viewTypedExample : String -> value -> value -> Html Never
-viewTypedExample name actual expected =
-    Html.div []
-        [ goalHeading name
-        , viewAssertion (actual == expected)
-            (name)
-            (toString actual)
-            (toString expected)
-        ]
-
-
 viewAssertion : Bool -> String -> String -> String -> Html Never
 viewAssertion isCorrect call actual expected =
     if isCorrect then
@@ -396,7 +385,7 @@ colorToCssString color =
             Color.toRgb color
     in
         String.concat
-            [ "rgb("
+            [ "rgb(`"
             , toString components.red
             , ","
             , toString components.green

--- a/Main.elm
+++ b/Main.elm
@@ -43,6 +43,7 @@ sayHello friendsName =
 
 formatPhoneNumber : String -> String -> String -> String
 formatPhoneNumber areaCode exchange local =
+    -- desired format: (999) 999-9999
     "TODO: implement me"
 
 

--- a/Main.elm
+++ b/Main.elm
@@ -114,7 +114,7 @@ createPoint x y =
     "TODO: implement me"
 
 
-kingPhilipCanOrderFindGreenSocks animal =
+kingPhilipCanOrderFineGreenSocks animal =
     -- given an animal, return a list of that animal's classification,
     -- in the order: Species, Genus, Order, Family, Class, Phylum, Kingdom
     []
@@ -208,8 +208,8 @@ main =
             , ( ( -3, 7 ), "{ x = -3, y = 7 }" )
             ]
         , viewFunctionExample1
-            "kingPhilipCanOrderFindGreenSocks"
-            kingPhilipCanOrderFindGreenSocks
+            "kingPhilipCanOrderFineGreenSocks"
+            kingPhilipCanOrderFineGreenSocks
             [ ( { name = "Lassie"
                 , species =
                     { name = "Canis familiaris"
@@ -436,7 +436,7 @@ colorToCssString color =
             Color.toRgb color
     in
         String.concat
-            [ "rgb(`"
+            [ "rgb("
             , toString components.red
             , ","
             , toString components.green

--- a/Main.elm
+++ b/Main.elm
@@ -110,11 +110,10 @@ createPoint x y =
 
 
 grandmotherNames person =
-    "TODO: implement me"
-
-
-tradePlaces a b =
-    "TODO: implement me"
+    -- Given a person, return a list of the person's grandmothers
+    -- (person is going to be a record with a mother field and a father field,
+    -- who also have mother and father fields)
+    []
 
 
 
@@ -127,6 +126,12 @@ signAndMagnitude : Int -> ( String, Int )
 signAndMagnitude x =
     -- TODO: implement me
     ( "TODO", 0 )
+
+
+tradePlaces a b =
+    -- Given two records representing items, each with a description field and
+    -- a location field, "trade" the locations of the items
+    "TODO: implement me"
 
 
 

--- a/Main.elm
+++ b/Main.elm
@@ -193,9 +193,11 @@ main =
             , ( [ "Octothorpe", "Octohash" ], [] )
             ]
         , Html.h2 [] [ Html.text "Records" ]
-        , viewUntypedExample "createPoint"
-            (createPoint 4 2)
-            "{ x = 4, y = 2 }"
+        , viewUntypedFunctionExample2 "createPoint"
+            createPoint
+            [ ( ( 4, 2 ), "{ x = 4, y = 2 }" )
+            , ( ( -3, 7 ), "{ x = -3, y = 7 }" )
+            ]
         , viewUntypedExample "grandmotherNames"
             (grandmotherNames
                 { name = "Lisa Simpson"
@@ -453,6 +455,15 @@ viewFunctionExample2 name function testCases =
         (\( a, b ) -> toString a ++ " " ++ toString b)
         name
         (\( a, b ) -> function a b)
+        testCases
+
+
+viewUntypedFunctionExample2 : String -> (a -> b -> value) -> List ( ( a, b ), String ) -> Html Never
+viewUntypedFunctionExample2 name function testCases =
+    viewFunctionExampleN
+        (\( a, b ) -> toString a ++ " " ++ toString b)
+        name
+        (\( a, b ) -> toString (function a b))
         testCases
 
 

--- a/Main.elm
+++ b/Main.elm
@@ -109,10 +109,9 @@ createPoint x y =
     "TODO: implement me"
 
 
-grandmotherNames person =
-    -- Given a person, return a list of the person's grandmothers
-    -- (person is going to be a record with a mother field and a father field,
-    -- who also have mother and father fields)
+kingPhilipCanOrderFindGreenSocks animal =
+    -- given an animal, return a list of that animal's classification,
+    -- in the order: Species, Genus, Order, Family, Class, Phylum, Kingdom
     []
 
 
@@ -203,22 +202,56 @@ main =
             [ ( ( 4, 2 ), "{ x = 4, y = 2 }" )
             , ( ( -3, 7 ), "{ x = -3, y = 7 }" )
             ]
-        , viewUntypedExample "grandmotherNames"
-            (grandmotherNames
-                { name = "Lisa Simpson"
-                , mother =
-                    { name = "Marge Bouvier Simpson"
-                    , mother = { name = "Jackie Gurney Bouvier" }
-                    , father = { name = "Clancy Bouvier" }
-                    }
-                , father =
-                    { name = "Homer Simpson"
-                    , mother = { name = "Mona Olsen" }
-                    , father = { name = "Abraham Simpson" }
+        , viewFunctionExample1
+            "kingPhilipCanOrderFindGreenSocks"
+            kingPhilipCanOrderFindGreenSocks
+            [ ( { name = "Lassie"
+                , species =
+                    { name = "Canis familiaris"
+                    , genus =
+                        { name = "Canis"
+                        , family =
+                            { name = "Canidae"
+                            , order =
+                                { name = "Carnivora"
+                                , class =
+                                    { name = "Mammalia"
+                                    , phylum =
+                                        { name = "Chordata"
+                                        , kingdom = { name = "Animalia" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
-            )
-            (toString [ "Mona Olsen", "Jackie Gurney Bouvier" ])
+              , [ "Canis familiaris", "Canis", "Canidae", "Carnivora", "Mammalia", "Chordata", "Animalia" ]
+              )
+            , ( { name = "Garfield"
+                , species =
+                    { name = "Felis catus"
+                    , genus =
+                        { name = "Felis"
+                        , family =
+                            { name = "Felinae"
+                            , order =
+                                { name = "Carnivora"
+                                , class =
+                                    { name = "Mammalia"
+                                    , phylum =
+                                        { name = "Chordata"
+                                        , kingdom = { name = "Animalia" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+              , [ "Felis catus", "Felis", "Felinae", "Carnivora", "Mammalia", "Chordata", "Animalia" ]
+              )
+            ]
         , viewUntypedFunctionExample2 "tradePlaces"
             tradePlaces
             [ ( ( { description = "clean towels"
@@ -311,17 +344,6 @@ font-size: 15px;
 line-height: 25px;
 }
 """ ]
-        ]
-
-
-viewUntypedExample : String -> value -> String -> Html Never
-viewUntypedExample name actual expected =
-    Html.div []
-        [ goalHeading name
-        , viewAssertion ((toString actual) == expected)
-            (name)
-            (toString actual)
-            expected
         ]
 
 
@@ -419,11 +441,6 @@ colorToCssString color =
             ]
 
 
-viewFunctionExample1 : String -> (a -> value) -> List ( a, value ) -> Html Never
-viewFunctionExample1 =
-    viewFunctionExampleN toString
-
-
 viewFunctionExampleN : (a -> String) -> String -> (a -> value) -> List ( a, value ) -> Html Never
 viewFunctionExampleN argsToString name function testCases =
     let
@@ -469,6 +486,11 @@ goalHeading name =
         , inlineCode name
         , Html.text " function so that the following tests pass:"
         ]
+
+
+viewFunctionExample1 : String -> (a -> value) -> List ( a, value ) -> Html Never
+viewFunctionExample1 =
+    viewFunctionExampleN toString
 
 
 viewFunctionExample2 : String -> (a -> b -> value) -> List ( ( a, b ), value ) -> Html Never

--- a/Main.elm
+++ b/Main.elm
@@ -219,24 +219,25 @@ main =
                 }
             )
             (toString [ "Mona Olsen", "Jackie Gurney Bouvier" ])
-        , viewUntypedExample "tradePlaces"
-            (tradePlaces
-                { description = "clean towels"
-                , location = "Laundry room"
-                }
-                { description = "dirty towels"
-                , location = "Kitchen"
-                }
-            )
-            (toString
-                ( { description = "clean towels"
-                  , location = "Kitchen"
-                  }
-                , { description = "dirty towels"
+        , viewUntypedFunctionExample2 "tradePlaces"
+            tradePlaces
+            [ ( ( { description = "clean towels"
                   , location = "Laundry room"
                   }
+                , { description = "dirty towels"
+                  , location = "Kitchen"
+                  }
                 )
-            )
+              , toString
+                    ( { description = "clean towels"
+                      , location = "Kitchen"
+                      }
+                    , { description = "dirty towels"
+                      , location = "Laundry room"
+                      }
+                    )
+              )
+            ]
         , Html.h2 [] [ Html.text "Tuples" ]
         , viewFunctionExample1 "signAndMagnitude"
             signAndMagnitude


### PR DESCRIPTION
- don't allow createPoint to succeed with `x = 4, y = 2` or whatever
- replace grandmotherNames with a taxonomy thing
- adds an `unequal` section so that people find `/=` before they need it for the filtering one